### PR TITLE
Add dark mode support for dropdown icon.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,6 +10,8 @@ import CountryPicker, {
 import { PhoneNumberUtil } from "google-libphonenumber";
 import styles from "./styles";
 
+const dropDownWhite = 
+"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAABpSURBVHgB7c7JDcAwDANBleL+m2IpivPN6UOiYYAE+N4x0zRN0+rcvdTDecPZXIXALU5E4DVOQOA3nohAczwBge54IALD8QAEpuMTCITFBxDx8Q5EXrwBkR//QPDiDwh+/IIopmnazjsA9h+ezKBcStUAAAAASUVORK5CYII=";
 const dropDown =
   "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAi0lEQVRYR+3WuQ6AIBRE0eHL1T83FBqU5S1szdiY2NyTKcCAzU/Y3AcBXIALcIF0gRPAsehgugDEXnYQrUC88RIgfpuJ+MRrgFmILN4CjEYU4xJgFKIa1wB6Ec24FuBFiHELwIpQxa0ALUId9wAkhCnuBdQQ5ngP4I9wxXsBDyJ9m+8y/g9wAS7ABW4giBshQZji3AAAAABJRU5ErkJggg==";
 const phoneUtil = PhoneNumberUtil.getInstance();
@@ -118,9 +120,10 @@ export default class PhoneInput extends PureComponent {
   }
 
   renderDropdownImage = () => {
+    const { withDarkTheme } = this.props
     return (
       <Image
-        source={{ uri: dropDown }}
+        source={{ uri: withDarkTheme ? dropDownWhite : dropDown }}
         resizeMode="contain"
         style={styles.dropDownImage}
       />


### PR DESCRIPTION
- Add a white dropdown icon base64 string.
- Show the white dropdown icon when withDarkTheme resolves true instead of the default black.

Fix :-  #7

![WhatsApp Image 2021-11-01 at 10 01 35 AM (1)](https://user-images.githubusercontent.com/54940154/139622952-e01df344-6180-490e-921d-fb665335c4d4.jpeg)
Before

![WhatsApp Image 2021-11-01 at 10 16 31 AM](https://user-images.githubusercontent.com/54940154/139622955-71c49ae7-d65d-41b6-9dc5-98039f97b827.jpeg)
After

